### PR TITLE
Update backPropagation.cpp

### DIFF
--- a/src/neural_network/backPropagation.cpp
+++ b/src/neural_network/backPropagation.cpp
@@ -97,7 +97,7 @@ void NeuralNetwork::backPropagation() {
 
     hiddenDerived       = this->layers.at(i)->matrixifyDerivedVals();
 
-    for(int colCounter = 0; colCounter < hiddenDerived->getNumRows(); colCounter++) {
+    for(int colCounter = 0; colCounter < hiddenDerived->getNumCols(); colCounter++) {
       double  g = gradients->getValue(0, colCounter) * hiddenDerived->getValue(0, colCounter);
       gradients->setValue(0, colCounter, g);
     }
@@ -105,7 +105,7 @@ void NeuralNetwork::backPropagation() {
     if(i == 1) {
       zActivatedVals  = this->layers.at(0)->matrixifyVals();
     } else {
-      zActivatedVals  = this->layers.at(0)->matrixifyActivatedVals();
+      zActivatedVals  = this->layers.at(i-1)->matrixifyActivatedVals();
     }
 
     transposedHidden  = zActivatedVals->transpose();


### PR DESCRIPTION
AT ITERATION colcounter = replace getNumCols with getNumRows , because every layer has only one row , by putting it into iteration does'nt make sense if we put NumCols only then we can equally multiply both matrices

And  main Mistake is in checking condition :- 
 if(i == 1) {
      zActivatedVals  = this->layers.at(0)->matrixifyVals();
    } else {
      zActivatedVals  = this->layers.at(0)->matrixifyActivatedVals();
    }

First condition is ok ,when we are just ahead of our input layer.

But at else condition when we are at some arbitrary hidden or convolution layer it have to point towards its next hidden layer (when we are comming back) but in this file it's always points towards the input layer which is very odd.

SORY IF I AM WRONG.