### PR TITLE
fix gradients dangling pointer

### DIFF
--- a/src/neural_network/backPropagation.cpp
+++ b/src/neural_network/backPropagation.cpp
@@ -147,6 +147,7 @@ void NeuralNetwork::backPropagation() {
     delete tempNewWeights;
     delete deltaWeights;
   }
+  delete gradients;
 
   for(int i = 0; i < this->weightMatrices.size(); i++) {
     delete this->weightMatrices[i];


### PR DESCRIPTION
`valgrind --leak-check=full` reported a memory leak in `backPropagation.cpp`